### PR TITLE
Switch Docker base image to Debian slim for reliable Vite builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Use Node.js 20
-FROM node:20-alpine
+FROM node:20-bullseye-slim
 
 # Install build dependencies for native modules
-RUN apk add --no-cache python3 make g++
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -32,4 +34,3 @@ ENV NODE_ENV=production
 
 # Start the application
 CMD ["node", "dist/index.js"]
-


### PR DESCRIPTION
### Motivation
- Replace the Alpine base image because Vite/Rollup fails to locate musl-specific optional native modules on Alpine (`@rollup/rollup-linux-x64-musl`), so using Debian slim avoids the musl/optional-dependency issue during builds.

### Description
- Update `Dockerfile` to use `node:20-bullseye-slim` and install build dependencies with `apt-get update && apt-get install -y python3 make g++` instead of `apk add`, leaving the rest of the build steps unchanged.

### Testing
- No automated tests were executed for this change since it is a `Dockerfile`-only update; recommend running a `docker build` to validate the Vite build in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f641b82883258038861bd50e465a)