### PR TITLE
Fix native dependency resolution in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /app
 
 # Copy package files and install dependencies
 COPY package*.json ./
-RUN npm ci
+# Use npm install instead of npm ci to properly resolve platform-specific
+# native dependencies (like @rollup/rollup-linux-x64-gnu) for the Linux container
+RUN npm install --include=optional
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
Updated the Dockerfile to use `npm install` instead of `npm ci` to properly resolve platform-specific native dependencies during the Docker build process.

## Changes
- Replaced `npm ci` with `npm install --include=optional` in the Docker build step
- Added explanatory comment documenting why this change is necessary for resolving platform-specific native dependencies (e.g., `@rollup/rollup-linux-x64-gnu`)

## Details
The `npm ci` (clean install) command is stricter and uses exact versions from `package-lock.json`, but it doesn't properly handle optional platform-specific native dependencies in containerized environments. By switching to `npm install --include=optional`, the build process can now correctly resolve and install native binaries compiled for the Linux container environment, preventing runtime errors related to missing platform-specific dependencies.

https://claude.ai/code/session_01NU9q5FwpHSSurCJJBku754