### PR TITLE
Normalize session cookie domain for auth stability

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -76,6 +76,10 @@ export function setupAuth(app: Express) {
     tableName: "sessions",
   });
 
+  const normalizedCookieDomain = process.env.COOKIE_DOMAIN?.startsWith("www.")
+    ? process.env.COOKIE_DOMAIN.slice(4)
+    : process.env.COOKIE_DOMAIN;
+
   const sessionSettings: session.SessionOptions = {
     secret: process.env.SESSION_SECRET!,
     store: sessionStore,
@@ -87,7 +91,7 @@ export function setupAuth(app: Express) {
       // This prevents login loops when running production builds locally or on HTTP
       secure: process.env.NODE_ENV === "production" && process.env.DISABLE_SECURE_COOKIES !== "true",
       sameSite: "lax",
-      domain: process.env.COOKIE_DOMAIN || undefined, 
+      domain: normalizedCookieDomain || undefined, 
       maxAge: sessionTtl,
     },
   };


### PR DESCRIPTION
### Motivation
- Prevent auth/session cookie mismatches when the site is accessed as `www.example.com` vs `example.com` by normalizing `COOKIE_DOMAIN` so cookies apply consistently across root and `www` hosts.

### Description
- Introduced `normalizedCookieDomain` in `server/auth.ts` which strips a leading `www.` from `process.env.COOKIE_DOMAIN` and used it for the session cookie `domain` setting to avoid domain-scoped cookie issues.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982e1eeb33c8325a208e11fb776380a)