### PR TITLE
Add @rollup/rollup-linux-x64-gnu optional dependency to fix Vite build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
         "vite": "^5.4.20"
       },
       "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.24.4",
         "bufferutil": "^4.0.8"
       }
     },
@@ -3026,6 +3027,9 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "optional": true
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.3",
@@ -9899,6 +9903,70 @@
         "@rollup/rollup-win32-x64-msvc": "4.24.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm-eabi": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "vite": "^5.4.20"
   },
   "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "4.24.4",
     "bufferutil": "^4.0.8"
   }
 }


### PR DESCRIPTION
### Motivation
- The Docker build failed during `npx vite build` with a missing native Rollup module error (`Cannot find module @rollup/rollup-linux-x64-gnu`) which prevented client bundling. 
- Ensure the platform-specific native Rollup binary is declared as an optional dependency so Vite/Rollup can load the correct native binding during builds.

### Description
- Added `@rollup/rollup-linux-x64-gnu` pinned to `4.24.4` under `optionalDependencies` in `package.json`. 
- Updated `package-lock.json` to include the optional dependency metadata and the corresponding rollup native entries so the lockfile reflects the new optional binary. 
- Ran `npm install --save-optional @rollup/rollup-linux-x64-gnu@4.24.4` and refreshed the lockfile, then committed the updated files.

### Testing
- Ran `npm install --package-lock-only` which completed successfully to regenerate lock metadata. 
- Ran `npm install --save-optional @rollup/rollup-linux-x64-gnu@4.24.4` which completed and added packages successfully. 
- Did not perform a full Docker image rebuild or run `npx vite build` inside the image as part of this change; only dependency and lockfile updates were verified via the npm commands above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982e606407483258eaec618f3b2ba05)