### PR TITLE
Fix rollup optional dependency entries in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3029,7 +3029,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "optional": true
+      "optional": true,
+      "version": "4.24.4",
+      "dev": true,
+      "license": "MIT",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.3",
@@ -9906,67 +9915,83 @@
     },
     "node_modules/rollup/node_modules/@rollup/rollup-android-arm-eabi": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-android-arm64": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-freebsd-arm64": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-freebsd-x64": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
       "dev": true,
-      "optional": true
+      "optional": true,
+      "version": "4.24.4"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",


### PR DESCRIPTION
### Motivation
- Prevent npm install failures caused by missing version metadata on Rollup platform-specific optional packages in `package-lock.json`. 
- Ensure CI/build reproducibility by aligning optional Rollup entries with expected `cpu`/`os` and version metadata.

### Description
- Populate missing `version`, `dev`, `license`, and `cpu`/`os` fields for `node_modules/@rollup/*` optional platform packages in `package-lock.json` to match the Rollup runtime package version. 
- Add `version` fields to nested optional Rollup packages under `node_modules/rollup/node_modules/@rollup/*` so nested platform binaries are consistent. 
- Persist the updated `package-lock.json` and commit the change to keep the lockfile coherent for downstream installs.

### Testing
- `npm install` (original) failed with `Invalid Version` during dependency resolution, confirming the problem. 
- `npm install --package-lock-only` was attempted but failed with a `403 Forbidden` from the registry, preventing regenerating the lockfile from the registry. 
- A local Python validation script was run which reported 17 missing `version` entries before the patch and 0 after the update, indicating the lockfile now contains the expected metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982e7f752b4832599d1b5590127dcdb)