### PR TITLE
Remove conditional page tracking for unauthenticated users

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -62,11 +62,6 @@ import DashboardManager from "@/pages/dashboard-manager";
 function Router() {
   const { user } = useAuth();
   const isClient = user?.role === 'client';
-  
-  // Track page views for non-authenticated pages
-  if (!user) {
-    usePageTracking();
-  }
 
   return (
     <Switch>


### PR DESCRIPTION
## Summary
Removed the conditional page tracking logic that was only executing for non-authenticated users in the Router component.

## Changes
- Removed the `usePageTracking()` hook call that was conditionally invoked when `!user`
- Deleted the associated conditional block and comment

## Details
The page tracking hook was previously only being called for unauthenticated users. This change removes that conditional logic entirely. This may indicate:
- Page tracking is being handled elsewhere in the application
- Page tracking should apply to all users (authenticated and unauthenticated) and will be implemented at a different level
- The tracking functionality is being deprecated or refactored

This simplifies the Router component by removing conditional logic that may have been redundant or no longer necessary.

https://claude.ai/code/session_01HcsFzfYGgQtqNHbfGmq5xE