### PR TITLE
Add missing Zap icon import to training.tsx

### DIFF
--- a/client/src/pages/training.tsx
+++ b/client/src/pages/training.tsx
@@ -29,6 +29,7 @@ import {
   Globe,
   Package,
   Sparkles,
+  Zap,
 } from "lucide-react";
 
 interface TrainingSection {


### PR DESCRIPTION
The Zap icon was used at line 218 but never imported, causing "Uncaught ReferenceError: Zap is not defined" which resulted in a blank white screen.

https://claude.ai/code/session_01HcsFzfYGgQtqNHbfGmq5xE