### PR TITLE
Remove debug logging and fix session regeneration order

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -44,21 +44,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const loginMutation = useMutation({
     mutationFn: async (credentials: LoginData) => {
-      // #region agent log
-      fetch('http://127.0.0.1:7243/ingest/80b2583d-14fd-4900-b577-b2baae4d468c',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId:'debug-session',runId:'login-pre',hypothesisId:'D',location:'client/src/hooks/use-auth.tsx:loginMutation',message:'Login mutation start',data:{username:credentials?.username?.slice?.(0,80),origin:window.location.origin,viteApiBaseUrl:(import.meta as any)?.env?.VITE_API_BASE_URL||null},timestamp:Date.now()})}).catch(()=>{});
-      // #endregion
-      try {
-        const res = await apiRequest("POST", "/api/login", credentials);
-        // #region agent log
-        fetch('http://127.0.0.1:7243/ingest/80b2583d-14fd-4900-b577-b2baae4d468c',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId:'debug-session',runId:'login-pre',hypothesisId:'D',location:'client/src/hooks/use-auth.tsx:loginMutation',message:'Login mutation response ok',data:{status:res.status},timestamp:Date.now()})}).catch(()=>{});
-        // #endregion
-        return await res.json();
-      } catch (e) {
-        // #region agent log
-        fetch('http://127.0.0.1:7243/ingest/80b2583d-14fd-4900-b577-b2baae4d468c',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId:'debug-session',runId:'login-pre',hypothesisId:'D',location:'client/src/hooks/use-auth.tsx:loginMutation',message:'Login mutation error',data:{error:String((e as any)?.message||e)},timestamp:Date.now()})}).catch(()=>{});
-        // #endregion
-        throw e;
-      }
+      const res = await apiRequest("POST", "/api/login", credentials);
+      return await res.json();
     },
     onSuccess: (user: SelectUser) => {
       queryClient.setQueryData(["/api/user"], user);


### PR DESCRIPTION
## Summary
This PR removes extensive debug logging code that was instrumented throughout the authentication flow and fixes a critical bug in the session regeneration logic during login.

## Key Changes

- **Removed debug logging**: Eliminated all agent debug logging calls (HTTP POST requests to `http://127.0.0.1:7243/ingest/...`) and file-based logging from both client and server authentication code
- **Removed unused imports**: Deleted the `appendFile` import and `agentAppendLog` function from `server/auth.ts`
- **Fixed session regeneration bug**: Corrected the order of operations in the login endpoint:
  - **Before**: Called `req.login()` first, then `req.session.regenerate()`, which wiped out the session data immediately after login
  - **After**: Now calls `req.session.regenerate()` first to create a new session, then calls `req.login()` to establish the user in that new session
- **Simplified client login mutation**: Removed try-catch wrapper and debug logging from the login mutation in `use-auth.tsx`
- **Removed console.log**: Deleted the login attempt console log from the `/api/login` endpoint

## Implementation Details

The session regeneration fix is critical for security (prevents session fixation attacks) and functionality. The previous implementation would regenerate the session after login, causing the authenticated user data to be lost. The corrected flow ensures:
1. Session is regenerated (new session ID issued)
2. User is authenticated into the new session via `req.login()`
3. Activity logging and response occur with the properly authenticated session

All debug instrumentation has been cleaned up, resulting in cleaner, more maintainable code.

https://claude.ai/code/session_014VgxZxoHrga77XmJ1r38s5