### PR TITLE
Fix marketing broadcast group recipients

### DIFF
--- a/server/marketingBroadcastProcessor.ts
+++ b/server/marketingBroadcastProcessor.ts
@@ -87,6 +87,7 @@ export async function processMarketingBroadcast(broadcastId: string) {
     }
 
     // 1.2 Handle Group audience
+    const individualRecipients: { email?: string; phone?: string; type: "individual" }[] = [];
     if (broadcast.audience === "group" && broadcast.groupId) {
       const members = await storage.getMarketingGroupMembers(broadcast.groupId);
       const leadIds = members.filter(m => m.leadId).map(m => m.leadId!);
@@ -131,7 +132,6 @@ export async function processMarketingBroadcast(broadcastId: string) {
     }
 
     // 1.5 Handle Individual Recipient
-    const individualRecipients: { email?: string; phone?: string; type: "individual" }[] = [];
     if (broadcast.audience === "individual" && broadcast.customRecipient) {
       if (broadcast.type === "email") {
         individualRecipients.push({ email: broadcast.customRecipient, type: "individual" });
@@ -261,4 +261,3 @@ export async function processMarketingBroadcast(broadcastId: string) {
     });
   }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent a runtime reference error when processing group broadcasts that include `custom_recipient` entries by ensuring the `individualRecipients` array is initialized before group handling in `server/marketingBroadcastProcessor.ts`.

### Description
- Initialize `individualRecipients` earlier and remove the duplicate declaration so group custom recipients can be pushed without throwing a reference error in `processMarketingBroadcast` (`server/marketingBroadcastProcessor.ts`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983cde73bc88325b001f56d49ee4c0f)