### PR TITLE
Add Marketing Center routes module

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,6 +7,7 @@ import { AuditService } from "./auditService";
 import { InstagramService } from "./instagramService";
 import { createCheckoutSession } from "./stripeService";
 import { dialpadService } from "./dialpadService";
+import marketingCenterRoutes from "./routes/marketing-center";
 import {
   insertClientSchema,
   insertCampaignSchema,
@@ -98,6 +99,9 @@ const upload = multer({
 });
 
 export function registerRoutes(app: Express) {
+  // Mount Marketing Center routes
+  app.use("/api/marketing-center", marketingCenterRoutes);
+
   // File upload endpoint
   app.post("/api/upload", isAuthenticated, upload.single('file'), async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
## Summary
Integrated a new Marketing Center routes module into the main application router, enabling API endpoints for marketing center functionality.

## Changes
- Imported the new `marketing-center` routes module from `./routes/marketing-center`
- Mounted the Marketing Center routes at the `/api/marketing-center` base path
- Routes are registered early in the middleware chain, before file upload endpoints

## Implementation Details
The Marketing Center routes are mounted as a sub-router using Express's `app.use()` method, following the existing pattern of modular route organization. This allows the marketing center functionality to be developed and maintained independently while being seamlessly integrated into the main application.

https://claude.ai/code/session_016NuJtzJcc8wPyJ49jNLtou