### PR TITLE
Fix MTD revenue metric calculation and formatting

### DIFF
--- a/client/src/pages/dashboard-admin.tsx
+++ b/client/src/pages/dashboard-admin.tsx
@@ -84,6 +84,16 @@ export default function AdminDashboard() {
     return Array.from({ length: 7 }, () => ({ value: baseValue }));
   };
 
+  const getCurrencyTickerProps = (value: number) => {
+    const isCompact = value >= 1000;
+
+    return {
+      value: isCompact ? value / 1000 : value,
+      suffix: isCompact ? 'k' : '',
+      decimalPlaces: isCompact ? 1 : 0,
+    };
+  };
+
   const metrics = [
     {
       title: "Total Clients",
@@ -409,12 +419,21 @@ export default function AdminDashboard() {
                         <div className="flex items-end justify-between gap-2">
                           <div className="text-3xl md:text-4xl font-bold tracking-tight font-mono" data-testid={`metric-${metric.title.toLowerCase().replace(/\s+/g, '-')}`}>
                             {typeof metric.displayValue === 'number' ? (
+                              (() => {
+                                const isCurrencyMetric = metric.title.includes('Revenue') || metric.title.includes('Value');
+                                const tickerProps = isCurrencyMetric
+                                  ? getCurrencyTickerProps(metric.displayValue)
+                                  : { value: metric.displayValue, suffix: '', decimalPlaces: 0 };
+
+                                return (
                               <NumberTicker 
-                                value={metric.displayValue} 
-                                prefix={metric.title.includes('Revenue') || metric.title.includes('Value') ? '$' : ''}
-                                suffix={metric.title.includes('Revenue') || metric.title.includes('Value') ? (metric.displayValue >= 1000 ? 'k' : '') : ''}
-                                decimalPlaces={metric.title.includes('Revenue') || metric.title.includes('Value') ? (metric.displayValue >= 1000 ? 1 : 0) : 0}
+                                value={tickerProps.value}
+                                prefix={isCurrencyMetric ? '$' : ''}
+                                suffix={isCurrencyMetric ? tickerProps.suffix : ''}
+                                decimalPlaces={tickerProps.decimalPlaces}
                               />
+                                );
+                              })()
                             ) : metric.value}
                           </div>
                           <div className={`flex items-center gap-0.5 text-xs md:text-sm font-semibold px-2 py-0.5 md:px-2.5 md:py-1 rounded-full flex-shrink-0 ${


### PR DESCRIPTION
### Motivation
- The admin dashboard’s "Revenue (MTD)" card showed zero when Stripe is not configured because the dashboard fallback skipped invoice-based revenue calculation. 
- Currency metrics used the unscaled raw value with a `'k'` suffix applied in the string, causing the `NumberTicker` to animate and display incorrect magnitudes.

### Description
- Added `storage.getInvoices()` to the dashboard aggregation and compute month-to-date revenue from paid invoices (filter paid invoices by `paidAt/updatedAt/createdAt` within the current month and sum `amount / 100`) in `server/routes.ts`.
- Introduced `getCurrencyTickerProps` in `client/src/pages/dashboard-admin.tsx` and updated `NumberTicker` usage so currency metrics are scaled (value divided by 1000 when compact), use a `k` suffix, and set appropriate `decimalPlaces` for formatted display.
- Files changed: `server/routes.ts` and `client/src/pages/dashboard-admin.tsx`.

### Testing
- Attempted to run the dev server with `npm run dev`, but it failed due to a missing environment file (error: `node: .env: not found`).
- No other automated tests were run in this environment; changes were committed successfully (`git commit`).
- Suggested automated checks (not executed here): verify `GET /api/dashboard/admin-stats` returns a non-zero `monthlyRevenue` when there are paid invoices this month, and validate UI formatting for values like `$950` and `$1.2k`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e91d347c8325bbfb49845ff1dba6)