### PR TITLE
Hide Analytics & Reports sidebar group

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -1551,18 +1551,6 @@ export function AppSidebar() {
                 forceOpen={hasFilter}
               />
 
-              {/* Analytics & Reports Group */}
-              <NavCollapsibleGroup
-                title="Analytics & Reports"
-                icon={BarChart3}
-                items={visibleAnalyticsReports}
-                location={location}
-                isCollapsed={isCollapsed}
-                onClick={handleNavClick}
-                getBadgeCount={getBadgeCount}
-                forceOpen={hasFilter}
-              />
-
               {/* Billing & Finance Group */}
               <NavCollapsibleGroup
                 title="Billing & Finance"


### PR DESCRIPTION
### Motivation
- Remove the "Analytics & Reports" navigation group from the sidebar to simplify the UI and prevent that section from rendering.

### Description
- Deleted the `NavCollapsibleGroup` for the "Analytics & Reports" group in `client/src/components/app-sidebar.tsx` so the section no longer appears in the sidebar.

### Testing
- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but the run failed due to a missing `.env`, so runtime verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ee2c0e088325894b2929090a0afe)