### PR TITLE
Fix admin dashboard sidebar link

### DIFF
--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -240,7 +240,7 @@ const salesAgentTools: SidebarNavItem[] = [
 const communicationTools: SidebarNavItem[] = [
   {
     title: "Dashboard",
-    url: "/admin",
+    url: "/dashboard-admin",
     icon: LayoutDashboard,
     permission: null,
     sidebarKey: "dashboard" as const,


### PR DESCRIPTION
### Motivation
- The sidebar "Dashboard" item pointed to the incorrect route (`/admin`) which navigated users away from the intended admin dashboard at `/dashboard-admin`.

### Description
- Update the dashboard nav item URL in `client/src/components/app-sidebar.tsx` from `"/admin"` to `"/dashboard-admin"` so the sidebar button directs to the correct admin dashboard.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ef7afd988325ac14acf0f7aef63a)