### PR TITLE
Initialize SMTP transporter before sending emails

### DIFF
--- a/server/emailService.ts
+++ b/server/emailService.ts
@@ -733,9 +733,13 @@ export const marketingTemplates = {
 // Send email function
 export async function sendEmail(to: string | string[], subject: string, html: string, options?: { from?: string, fromName?: string }) {
   console.log(`📧 sendEmail called - To: ${Array.isArray(to) ? to.join(', ') : to}, Subject: ${subject}`);
-  
+
   if (!transporter) {
-    console.warn('⚠️  Email not sent - service not configured (transporter is null)');
+    initializeEmailService();
+  }
+
+  if (!transporter) {
+    console.warn('⚠️  Email not sent - service not configured (missing SMTP env or init failed)');
     return { success: false, message: 'Email service not configured' };
   }
 


### PR DESCRIPTION
### Motivation
- Background notification emails were failing when the SMTP `transporter` had not been initialized at runtime, so sending should attempt a lazy init and log a clearer diagnostic when SMTP is not configured.

### Description
- In `server/emailService.ts` updated `sendEmail` to call `initializeEmailService()` when `transporter` is `null`, and emit a clearer warning (`Email service not configured (missing SMTP env or init failed)`) if initialization still fails.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698672931ee08325acc5140e6da92e93)