### PR TITLE
Fix kanban scroll layout on tasks page

### DIFF
--- a/client/src/pages/tasks.tsx
+++ b/client/src/pages/tasks.tsx
@@ -558,14 +558,14 @@ export default function TasksPage() {
     ];
     
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 h-full p-4 overflow-x-auto">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 h-full min-h-0 p-4 overflow-x-auto overflow-y-hidden">
         {columns.map((column) => {
           const columnTasks = filteredTasks.filter((task) => task.status === column.id);
           
           return (
             <div
               key={column.id}
-              className="flex flex-col h-full min-w-[200px] md:min-w-[240px] lg:min-w-[280px] bg-muted/30 rounded-xl border p-3 backdrop-blur-sm"
+              className="flex flex-col h-full min-h-0 min-w-[200px] md:min-w-[240px] lg:min-w-[280px] bg-muted/30 rounded-xl border p-3 backdrop-blur-sm"
               onDragOver={handleDragOver}
               onDrop={(e) => handleDrop(e, column.id)}
             >
@@ -584,7 +584,7 @@ export default function TasksPage() {
                 </Button>
               </div>
 
-              <div className="space-y-3 flex-1 overflow-y-auto pr-1 custom-scrollbar"
+              <div className="space-y-3 flex-1 min-h-0 overflow-y-auto pr-1 custom-scrollbar"
                 style={{ 
                   borderColor: draggedTask && draggedTask.status !== column.id ? 'hsl(var(--primary) / 0.3)' : 'transparent',
                   backgroundColor: draggedTask && draggedTask.status !== column.id ? 'hsl(var(--primary) / 0.05)' : 'transparent'
@@ -899,7 +899,7 @@ export default function TasksPage() {
 
       {/* Main Content */}
       <div className="flex-1 flex flex-col h-full overflow-hidden">
-        <div className="p-3 md:p-6 space-y-4 md:space-y-6 flex-1 overflow-y-auto">
+        <div className="p-3 md:p-6 space-y-4 md:space-y-6 shrink-0">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
             <div>
               <h1 className="text-xl md:text-2xl font-bold">Tasks</h1>
@@ -1758,7 +1758,7 @@ export default function TasksPage() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {viewMode === "kanban" ? renderKanbanView() : viewMode === "compact" ? renderCompactView() : renderListView()}
       </div>
         </div>


### PR DESCRIPTION
### Motivation

- Prevent the page header and controls from consuming the scrollable height and ensure the Kanban columns scroll internally so the page doesn't grow vertically when many tasks are present.

### Description

- Update `client/src/pages/tasks.tsx` to separate header area from the main scrollable content by replacing the header wrapper's `flex-1 overflow-y-auto` with `shrink-0` so it doesn't claim the scroll height.
- Make the main content area the single vertical scroll container by using `flex-1 min-h-0 overflow-y-auto` for the content wrapper.
- Constrain the Kanban grid and columns for internal scrolling by adding `min-h-0` and `overflow-y-hidden` to the grid, `min-h-0` to each column, and `min-h-0 overflow-y-auto` to the column task list so lists scroll inside columns instead of expanding the page.

### Testing

- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but the server could not start due to a missing `.env` file (no successful runtime verification possible in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69867b0061fc832592d6ec159f0a2f68)