### PR TITLE
Fix React Query v5 compatibility and improve dashboard stats

### DIFF
--- a/client/src/pages/dashboard-admin.tsx
+++ b/client/src/pages/dashboard-admin.tsx
@@ -27,14 +27,18 @@ export default function AdminDashboard() {
     if (!isAdmin) navigate(getDefaultDashboardPath(role));
   }, [isAdmin, navigate, role]);
   
-  const { data: stats, isLoading, error, refetch } = useQuery({
+  const { data: stats, isLoading, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ["/api/dashboard/admin-stats"],
     refetchInterval: 30000, // Auto-refresh every 30 seconds
     retry: 3,
-    onSuccess: () => {
-      setLastUpdatedAt(new Date());
-    },
   });
+
+  // Track when data was last refreshed (onSuccess removed in React Query v5)
+  useEffect(() => {
+    if (dataUpdatedAt > 0) {
+      setLastUpdatedAt(new Date(dataUpdatedAt));
+    }
+  }, [dataUpdatedAt]);
 
   const { data: stripeData } = useQuery({
     queryKey: ["/api/stripe/dashboard"],

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1153,10 +1153,10 @@ Body: ${emailBody.replace(/<[^>]*>/g, '').substring(0, 3000)}`;
   });
 
   // Dashboard stats - OPTIMIZED
-  const dashboardStatsHandler = async (_req: Request, res: Response) => {
+  const dashboardStatsHandler = async (req: Request, res: Response) => {
     try {
       console.log("🔍 Dashboard API called - fetching data...");
-      
+
       // Parse pagination parameters from query string
       const limit = parseInt(req.query.limit as string) || 100;
       const offset = parseInt(req.query.offset as string) || 0;
@@ -1294,7 +1294,8 @@ Body: ${emailBody.replace(/<[^>]*>/g, '').substring(0, 3000)}`;
           upcomingDeadlines.push({
             title: task.title,
             date: formatDeadlineDate(task.dueDate),
-            urgent: daysUntil <= 3,
+            urgent: daysUntil < 0,
+            soon: daysUntil >= 0 && daysUntil <= 3,
             timestamp: task.dueDate,
           });
         });
@@ -1309,6 +1310,12 @@ Body: ${emailBody.replace(/<[^>]*>/g, '').substring(0, 3000)}`;
         activeCampaigns,
         pipelineValue,
         monthlyRevenue,
+        totalLeads: leads.length,
+        // Percentage change indicators (static for now — historical tracking needed for real deltas)
+        clientsChange: "0",
+        campaignsChange: "0",
+        pipelineChange: "0",
+        revenueChange: "0",
         recentActivity: sortedActivity,
         upcomingDeadlines: sortedDeadlines,
         taskMetrics: {


### PR DESCRIPTION
## Summary
Updated the admin dashboard to be compatible with React Query v5 by replacing the deprecated `onSuccess` callback with a `useEffect` hook. Also improved the dashboard stats API with better deadline urgency logic and additional metrics.

## Key Changes

- **React Query v5 Migration**: Removed `onSuccess` callback from the admin stats query and replaced it with a `useEffect` hook that tracks `dataUpdatedAt` to update the last refresh timestamp
- **Deadline Urgency Logic**: Changed urgent deadline threshold from `<= 3 days` to `< 0 days` (overdue only) and added a new `soon` flag for tasks due within 3 days
- **Enhanced Dashboard Metrics**: Added `totalLeads` count and placeholder fields for percentage change indicators (`clientsChange`, `campaignsChange`, `pipelineChange`, `revenueChange`) to support future historical tracking
- **Code Cleanup**: Fixed unused parameter warning by using `req` in the dashboard stats handler and removed trailing whitespace

## Implementation Details

The React Query migration leverages the `dataUpdatedAt` timestamp returned by the hook to track when data was last refreshed, providing a cleaner approach than the deprecated callback pattern. The deadline urgency improvements provide better UX by distinguishing between overdue tasks (urgent) and tasks due soon (within 3 days).

The percentage change fields are currently static placeholders and will require historical data tracking to calculate actual deltas in a future update.

https://claude.ai/code/session_01U1cqr6f6rK5LXRu4o16icU