### PR TITLE
Hide completed recurring tasks from task list

### DIFF
--- a/client/src/pages/tasks.tsx
+++ b/client/src/pages/tasks.tsx
@@ -517,12 +517,14 @@ export default function TasksPage() {
   };
 
   const completedHiddenByToggle = !showCompleted
-    ? tasks.filter((t) => matchesBaseFilters(t) && t.status === "completed").length
+    ? tasks.filter((t) => matchesBaseFilters(t) && t.status === "completed" && !t.isRecurring).length
     : 0;
 
   const filteredTasks = useMemo(() => {
     const filtered = tasks.filter((task) => {
       if (!matchesBaseFilters(task)) return false;
+      // Always hide completed recurring tasks — a new instance already exists
+      if (task.status === "completed" && task.isRecurring) return false;
       if (!showCompleted && task.status === "completed") return false;
       return true;
     });


### PR DESCRIPTION
## Summary
Completed recurring tasks are now always hidden from the task list, since a new instance of the recurring task already exists. This prevents duplicate entries and reduces clutter.

## Changes
- Updated `completedHiddenByToggle` calculation to exclude recurring tasks from the count
- Added logic to filter out completed recurring tasks regardless of the `showCompleted` toggle state
- Completed recurring tasks are now permanently hidden while their new instances are displayed

## Implementation Details
The change ensures that when a recurring task is marked as completed, users see the newly generated instance instead of the old completed one. This is achieved by:
1. Filtering out tasks where `status === "completed" && isRecurring === true` before applying the `showCompleted` toggle
2. Updating the hidden count to accurately reflect only non-recurring completed tasks that are hidden by the toggle

https://claude.ai/code/session_0139TY6UDSz4rLH3QE16x58W