### PR TITLE
Add getTaskSpacesForAssignee method to filter spaces by user

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -108,7 +108,7 @@ import {
   type InsertMarketingBroadcastRecipient,
 } from "@shared/schema";
 import { db } from "./db";
-import { eq, desc, or, and, gte, count, sql, inArray } from "drizzle-orm";
+import { eq, desc, or, and, gte, count, sql, inArray, isNotNull } from "drizzle-orm";
 
 export interface IStorage {
   // User operations
@@ -135,6 +135,7 @@ export interface IStorage {
 
   // Task Spaces operations
   getTaskSpaces(): Promise<TaskSpace[]>;
+  getTaskSpacesForAssignee(userId: number): Promise<TaskSpace[]>;
   getTaskSpace(id: string): Promise<TaskSpace | undefined>;
   createTaskSpace(space: InsertTaskSpace): Promise<TaskSpace>;
   updateTaskSpace(id: string, data: Partial<InsertTaskSpace>): Promise<TaskSpace>;
@@ -464,6 +465,40 @@ export class DatabaseStorage implements IStorage {
   // Task Spaces operations
   async getTaskSpaces(): Promise<TaskSpace[]> {
     return await db.select().from(taskSpaces).orderBy(taskSpaces.order, taskSpaces.name);
+  }
+
+  async getTaskSpacesForAssignee(userId: number): Promise<TaskSpace[]> {
+    const allSpaces = await this.getTaskSpaces();
+
+    const assignedSpaceRows = await db
+      .select({ spaceId: tasks.spaceId })
+      .from(tasks)
+      .where(and(eq(tasks.assignedToId, userId), isNotNull(tasks.spaceId)))
+      .groupBy(tasks.spaceId);
+
+    const assignedSpaceIds = new Set(
+      assignedSpaceRows.map((r) => r.spaceId).filter((id): id is string => Boolean(id))
+    );
+
+    if (assignedSpaceIds.size === 0) return [];
+
+    const byId = new Map(allSpaces.map((s) => [s.id, s] as const));
+    const includeIds = new Set<string>();
+
+    const includeWithParents = (spaceId: string) => {
+      let current: TaskSpace | undefined = byId.get(spaceId);
+      while (current) {
+        if (includeIds.has(current.id)) break;
+        includeIds.add(current.id);
+        const parentId = current.parentSpaceId ?? null;
+        if (!parentId) break;
+        current = byId.get(parentId);
+      }
+    };
+
+    for (const id of assignedSpaceIds) includeWithParents(id);
+
+    return allSpaces.filter((s) => includeIds.has(s.id));
   }
 
   async getTaskSpace(id: string): Promise<TaskSpace | undefined> {


### PR DESCRIPTION
## Summary
Added a new method `getTaskSpacesForAssignee()` to the storage interface that retrieves task spaces assigned to a specific user, including parent spaces in the hierarchy.

## Changes
- Added `isNotNull` import from drizzle-orm for null checking in queries
- Added `getTaskSpacesForAssignee(userId: number)` method signature to `IStorage` interface
- Implemented `getTaskSpacesForAssignee()` in `DatabaseStorage` class with the following logic:
  - Queries all tasks assigned to the given user
  - Groups by `spaceId` to find unique spaces with assignments
  - Traverses the space hierarchy upward to include all parent spaces
  - Returns filtered list of spaces maintaining original order

## Implementation Details
The method uses a two-step approach:
1. Database query to find spaces with direct task assignments for the user
2. In-memory traversal to include parent spaces, ensuring the complete hierarchy is returned even if only a child space has assignments

This ensures users see the full context of their assigned tasks within the space hierarchy.

https://claude.ai/code/session_01LwfuhksJreuMyvYQgeMZV4