### PR TITLE
Add recurring tasks overview page and API endpoint

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import ClientAnalytics from "@/pages/client-analytics";
 import Clients from "@/pages/clients";
 import Campaigns from "@/pages/campaigns";
 import Tasks from "@/pages/tasks";
+import RecurringTasks from "@/pages/recurring-tasks";
 import Leads from "@/pages/leads";
 import Pipeline from "@/pages/pipeline";
 import Content from "@/pages/content";
@@ -99,6 +100,7 @@ function Router() {
       {!isClient && <ProtectedRoute path="/clients" component={Clients} />}
       {!isClient && <ProtectedRoute path="/campaigns" component={Campaigns} />}
       {!isClient && <ProtectedRoute path="/tasks" component={Tasks} />}
+      {!isClient && <ProtectedRoute path="/recurring-tasks" component={RecurringTasks} />}
       {!isClient && <ProtectedRoute path="/leads" component={Leads} />}
       {!isClient && <ProtectedRoute path="/pipeline" component={Pipeline} />}
       {!isClient && <ProtectedRoute path="/content" component={Content} />}

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -34,6 +34,7 @@ import {
   Zap,
   Search,
   FileText,
+  Repeat,
 } from "lucide-react";
 import { Logo } from "@/components/Logo";
 import { Button } from "@/components/ui/button";
@@ -265,6 +266,13 @@ const coreTools: SidebarNavItem[] = [
     icon: ListTodo,
     permission: null,
     sidebarKey: "tasks" as const,
+  },
+  {
+    title: "Recurring Tasks",
+    url: "/recurring-tasks",
+    icon: Repeat,
+    permission: null,
+    sidebarKey: "recurringTasks" as const,
   },
 ];
 

--- a/client/src/pages/recurring-tasks.tsx
+++ b/client/src/pages/recurring-tasks.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toLocaleDateStringEST } from "@/lib/dateUtils";
+
+type RecurringSeries = {
+  seriesId: string;
+  title: string;
+  recurringPattern: string;
+  recurringInterval: number;
+  recurringEndDate: string | null;
+  scheduleFrom: string;
+  totalInstances: number;
+  openInstances: number;
+  completedInstances: number;
+  lastInstanceDateKey: string;
+  nextInstanceDateKey: string | null;
+  latestTask: {
+    id: string;
+    status: string;
+    dueDate: string | null;
+    assignedToId: number | null;
+    clientId: string | null;
+    spaceId: string | null;
+  } | null;
+};
+
+const dateKeyToDisplay = (dateKey: string | null) => {
+  if (!dateKey) return "—";
+  return toLocaleDateStringEST(`${dateKey}T00:00:00`);
+};
+
+const cadenceLabel = (pattern: string, interval: number) => {
+  if (!pattern) return "—";
+  const prefix = interval > 1 ? `Every ${interval} ` : "Every ";
+  return `${prefix}${pattern}`;
+};
+
+export default function RecurringTasksPage() {
+  const [search, setSearch] = useState("");
+
+  const { data: series = [], isLoading } = useQuery<RecurringSeries[]>({
+    queryKey: ["/api/tasks/recurring-series"],
+  });
+
+  const filteredSeries = useMemo(() => {
+    const normalized = search.trim().toLowerCase();
+    if (!normalized) return series;
+    return series.filter((item) => item.title.toLowerCase().includes(normalized));
+  }, [search, series]);
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Recurring Tasks</h1>
+          <p className="text-sm text-muted-foreground">
+            Track all recurring task series in one place and see what is coming up next.
+          </p>
+        </div>
+        <div className="max-w-md">
+          <Input
+            placeholder="Search recurring tasks..."
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </div>
+      </header>
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Card key={`recurring-skeleton-${index}`}>
+              <CardContent className="p-5">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="mt-3 h-4 w-56" />
+                <Skeleton className="mt-4 h-16 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : filteredSeries.length === 0 ? (
+        <Card>
+          <CardContent className="p-6 text-sm text-muted-foreground">
+            No recurring tasks found yet. Create a recurring task to see it listed here.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {filteredSeries.map((item) => (
+            <Card key={item.seriesId}>
+              <CardContent className="p-5 flex flex-col gap-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-lg font-semibold">{item.title}</h2>
+                    <p className="text-sm text-muted-foreground">
+                      {cadenceLabel(item.recurringPattern, item.recurringInterval)}
+                    </p>
+                  </div>
+                  <Badge variant={item.openInstances > 0 ? "default" : "secondary"}>
+                    {item.openInstances} open
+                  </Badge>
+                </div>
+
+                <div className="grid gap-2 text-sm text-muted-foreground">
+                  <div className="flex items-center justify-between">
+                    <span>Last instance</span>
+                    <span className="font-medium text-foreground">
+                      {dateKeyToDisplay(item.lastInstanceDateKey)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Next instance</span>
+                    <span className="font-medium text-foreground">
+                      {dateKeyToDisplay(item.nextInstanceDateKey)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Completed</span>
+                    <span className="font-medium text-foreground">
+                      {item.completedInstances}/{item.totalInstances}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Series ends</span>
+                    <span className="font-medium text-foreground">
+                      {item.recurringEndDate ? toLocaleDateStringEST(item.recurringEndDate) : "No end date"}
+                    </span>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a single place to view and manage recurring task series so staff can see what is scheduled and what instances are open or completed.
- Expose a lightweight server endpoint that groups recurring task instances into series and computes last/next instance info for UI consumption.

### Description
- Added a server API `GET /api/tasks/recurring-series` in `server/routes/tasks.ts` that groups tasks by `recurrenceSeriesId` (falling back to `stableRecurrenceSeriesId`) and returns per-series metadata including last/next instance keys, counts, cadence and a representative `latestTask` object.
- Exported and reused `stableRecurrenceSeriesId` from `server/lib/recurringTaskBackfill.ts` to reliably identify series when `recurrenceSeriesId` is missing.
- Implemented a new frontend page `client/src/pages/recurring-tasks.tsx` that fetches `/api/tasks/recurring-series`, provides search, and shows card-based summaries (cadence, last/next instance, open/completed counts, series end date).
- Wired the page into the app by adding the route in `client/src/App.tsx` and a sidebar nav entry in `client/src/components/app-sidebar.tsx` (icon `Repeat`) so staff can access the view.

### Testing
- Attempted to start the dev server with `npm run dev`, but it failed due to a missing `.env` in this environment, so the UI/server were not validated end-to-end (failed).
- No automated unit/integration tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876f29f5e8832598a7ee3fc078f996)