### PR TITLE
Fix client and admin navigation route paths

### DIFF
--- a/client/src/components/MobileNav.tsx
+++ b/client/src/components/MobileNav.tsx
@@ -58,10 +58,10 @@ export function MobileNav() {
   const getNavItems = () => {
     if (role === 'client') {
       return [
-        { title: "Home", url: "/client", icon: LayoutDashboard },
-        { title: "Campaigns", url: "/client/campaigns", icon: Megaphone },
-        { title: "Content", url: "/client/content", icon: Calendar },
-        { title: "Second Me", url: "/client/second-me", icon: Sparkles },
+        { title: "Home", url: "/client-dashboard", icon: LayoutDashboard },
+        { title: "Campaigns", url: "/client-campaigns", icon: Megaphone },
+        { title: "Content", url: "/client-content", icon: Calendar },
+        { title: "Second Me", url: "/second-me", icon: Sparkles },
         { title: "Tickets", url: "/tickets", icon: Ticket },
       ];
     }
@@ -93,8 +93,8 @@ export function MobileNav() {
     if (role === "client") {
       return [
         { label: "Go to Tickets", url: "/tickets" },
-        { label: "Go to Campaigns", url: "/client/campaigns" },
-        { label: "Go to Content", url: "/client/content" },
+        { label: "Go to Campaigns", url: "/client-campaigns" },
+        { label: "Go to Content", url: "/client-content" },
         { label: "Settings", url: "/settings" },
       ];
     }
@@ -295,7 +295,6 @@ export function MobileNav() {
     </>
   );
 }
-
 
 
 

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -109,32 +109,32 @@ type SubNavItem = {
 const clientTools: SidebarNavItem[] = [
   {
     title: "Dashboard",
-    url: "/client",
+    url: "/client-dashboard",
     icon: LayoutDashboard,
   },
   {
     title: "My Campaigns",
-    url: "/client/campaigns",
+    url: "/client-campaigns",
     icon: Megaphone,
   },
   {
     title: "My Content",
-    url: "/client/content",
+    url: "/client-content",
     icon: Calendar,
   },
   {
     title: "Analytics",
-    url: "/client/analytics",
+    url: "/client-analytics",
     icon: BarChart3,
   },
   {
     title: "Billing",
-    url: "/client/billing",
+    url: "/client-billing",
     icon: DollarSign,
   },
   {
     title: "AI Digital Twin",
-    url: "/client/second-me",
+    url: "/second-me",
     icon: Sparkles,
   },
   {
@@ -411,7 +411,7 @@ const financeBillingTools: SidebarNavItem[] = [
 const aiTools: SidebarNavItem[] = [
   {
     title: "AI Digital Twin",
-    url: "/admin/second-me",
+    url: "/admin-second-me",
     icon: Sparkles,
     permission: "canManageClients" as const,
     sidebarKey: "secondMe" as const,


### PR DESCRIPTION
### Motivation
- Prevent broken navigation by aligning sidebar and mobile navigation URLs with the app's actual route paths for client pages and the AI "Second Me" features.
- Make admin and client links consistent so users land on the intended client dashboard, content, campaigns, billing, analytics, and Second Me pages.

### Description
- Updated client sidebar routes in `client/src/components/app-sidebar.tsx` to use `/client-dashboard`, `/client-campaigns`, `/client-content`, `/client-analytics`, `/client-billing`, and `/second-me` so they match the application's registered routes.
- Changed the admin AI Digital Twin entry in `client/src/components/app-sidebar.tsx` from `/admin/second-me` to `/admin-second-me` to match the admin route naming convention.
- Synchronized mobile navigation and quick-action links in `client/src/components/MobileNav.tsx` to the same `/client-dashboard`, `/client-campaigns`, `/client-content`, and `/second-me` URLs to ensure consistent behavior across devices.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698772bd53c08325b4ecb3aab6ca2900)