### PR TITLE
Add migration to add task_spaces.is_hidden column

### DIFF
--- a/migrations/20260207_add_task_space_is_hidden.sql
+++ b/migrations/20260207_add_task_space_is_hidden.sql
@@ -1,0 +1,6 @@
+ALTER TABLE task_spaces
+ADD COLUMN IF NOT EXISTS is_hidden BOOLEAN DEFAULT false;
+
+UPDATE task_spaces
+SET is_hidden = false
+WHERE is_hidden IS NULL;


### PR DESCRIPTION
### Motivation
- Requests to `/api/task-spaces` were failing with `column "is_hidden" does not exist`, indicating the database schema is missing the `is_hidden` column referenced in the code.
- The ORM model `shared/schema.ts` already defines `isHidden: boolean("is_hidden").default(false)`, so the DB needs a matching column to avoid runtime errors.
- Add a migration to align the database schema with the application model and prevent 500 errors when fetching task spaces.

### Description
- Add a new migration file `migrations/20260207_add_task_space_is_hidden.sql` that runs `ALTER TABLE task_spaces ADD COLUMN IF NOT EXISTS is_hidden BOOLEAN DEFAULT false;` to create the column if missing.
- The migration also backfills existing rows with `UPDATE task_spaces SET is_hidden = false WHERE is_hidden IS NULL;` to ensure no null values.
- This change is a database-only migration and does not modify application code.

### Testing
- No automated tests were run for this change because it is a schema migration only and requires applying to the target database to validate.
- To verify, apply the migration against a test database and confirm that `SELECT is_hidden FROM task_spaces LIMIT 1;` returns a boolean column without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987746f2afc8325ad339d829f925bcf)