### PR TITLE
Allow clearing due dates with optional field indicator

### DIFF
--- a/client/src/components/TaskDetailSidebar.tsx
+++ b/client/src/components/TaskDetailSidebar.tsx
@@ -26,6 +26,7 @@ import {
   Briefcase,
   FolderOpen,
   Clock,
+  X,
 } from "lucide-react";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -125,9 +126,14 @@ export function TaskDetailSidebar({ task, isOpen, onClose, onDelete }: TaskDetai
   };
 
   const handleFieldUpdate = (field: string, value: any) => {
-    if (field === "dueDate" && value) {
-      const parsed = parseInputDateEST(`${value}T23:59`);
-      updateTaskMutation.mutate({ [field]: parsed.toISOString() } as any);
+    if (field === "dueDate") {
+      if (value) {
+        const parsed = parseInputDateEST(`${value}T23:59`);
+        updateTaskMutation.mutate({ [field]: parsed.toISOString() } as any);
+      } else {
+        // Explicitly clear the due date
+        updateTaskMutation.mutate({ [field]: null } as any);
+      }
     } else if (field === "assignedToId") {
       const parsed = value ? parseInt(value) : null;
       updateTaskMutation.mutate({ [field]: parsed } as any);
@@ -352,13 +358,26 @@ export function TaskDetailSidebar({ task, isOpen, onClose, onDelete }: TaskDetai
                   <label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
                     <Calendar className="w-3.5 h-3.5" />
                     Due Date
+                    <span className="normal-case font-normal">(Optional)</span>
                   </label>
-                  <Input
-                    type="date"
-                    value={task.dueDate ? toInputDateEST(task.dueDate) : ""}
-                    onChange={(e) => handleFieldUpdate("dueDate", e.target.value)}
-                    className="w-full h-9"
-                  />
+                  <div className="relative">
+                    <Input
+                      type="date"
+                      value={task.dueDate ? toInputDateEST(task.dueDate) : ""}
+                      onChange={(e) => handleFieldUpdate("dueDate", e.target.value)}
+                      className="w-full h-9"
+                    />
+                    {task.dueDate && (
+                      <button
+                        type="button"
+                        onClick={() => handleFieldUpdate("dueDate", "")}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-full hover:bg-muted text-muted-foreground"
+                        title="Clear due date"
+                      >
+                        <X className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 {/* Client */}

--- a/client/src/pages/tasks.tsx
+++ b/client/src/pages/tasks.tsx
@@ -348,10 +348,10 @@ export default function TasksPage() {
         status: data.status,
         priority: data.priority,
       };
-      
+
       // Only add optional fields if they have values
       if (data.description) taskData.description = data.description;
-      
+
       // Combine date and time if both are provided, using EST timezone
       if (data.dueDate) {
         if (data.dueTime) {
@@ -361,6 +361,9 @@ export default function TasksPage() {
           // Parse as EST date, set to end of day (11:59 PM EST)
           taskData.dueDate = parseInputDateEST(`${data.dueDate}T23:59`).toISOString();
         }
+      } else {
+        // Explicitly clear due date when not provided
+        taskData.dueDate = null;
       }
       
       if (data.campaignId) taskData.campaignId = data.campaignId;
@@ -1364,9 +1367,21 @@ export default function TasksPage() {
                       name="dueDate"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Due Date</FormLabel>
+                          <FormLabel>Due Date (Optional)</FormLabel>
                           <FormControl>
-                            <Input type="date" {...field} data-testid="input-task-due-date" />
+                            <div className="relative">
+                              <Input type="date" {...field} data-testid="input-task-due-date" />
+                              {field.value && (
+                                <button
+                                  type="button"
+                                  onClick={() => field.onChange("")}
+                                  className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-full hover:bg-muted text-muted-foreground"
+                                  title="Clear due date"
+                                >
+                                  <X className="w-3.5 h-3.5" />
+                                </button>
+                              )}
+                            </div>
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -1711,9 +1726,21 @@ export default function TasksPage() {
                     name="dueDate"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Due Date</FormLabel>
+                        <FormLabel>Due Date (Optional)</FormLabel>
                         <FormControl>
-                          <Input type="date" {...field} />
+                          <div className="relative">
+                            <Input type="date" {...field} />
+                            {field.value && (
+                              <button
+                                type="button"
+                                onClick={() => field.onChange("")}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-full hover:bg-muted text-muted-foreground"
+                                title="Clear due date"
+                              >
+                                <X className="w-3.5 h-3.5" />
+                              </button>
+                            )}
+                          </div>
                         </FormControl>
                         <FormMessage />
                       </FormItem>


### PR DESCRIPTION
## Summary
This PR enhances the due date handling across task management forms by making the field explicitly optional and adding the ability to clear previously set due dates.

## Key Changes
- **TaskDetailSidebar**: Added clear button (X icon) next to due date input that appears when a date is set, allowing users to remove the due date
- **TaskDetailSidebar**: Updated due date field label to indicate "(Optional)" status
- **TaskDetailSidebar**: Modified `handleFieldUpdate` to explicitly handle clearing due dates by sending `null` value
- **TasksPage**: Added clear button functionality to both task creation and edit forms with consistent styling
- **TasksPage**: Updated form labels to indicate due date is optional
- **TasksPage**: Enhanced form submission logic to explicitly set `dueDate` to `null` when not provided
- **Imports**: Added `X` icon from lucide-react for the clear button UI

## Implementation Details
- Clear buttons are conditionally rendered only when a due date value exists
- Clear functionality uses the same update mechanism as date selection
- Styling is consistent across all forms with absolute positioning and hover effects
- Minor code cleanup (trailing whitespace removal in tasks.tsx)

https://claude.ai/code/session_01PYbpbt3sBkUQmYQ7h8h9fn