### PR TITLE
Add polling intervals for real-time task and activity updates

### DIFF
--- a/client/src/components/TaskSpacesSidebar.tsx
+++ b/client/src/components/TaskSpacesSidebar.tsx
@@ -26,6 +26,7 @@ export function TaskSpacesSidebar({ onSpaceSelect, selectedSpaceId }: {
 
   const { data: spaces = [], isLoading } = useQuery<TaskSpace[]>({
     queryKey: ["/api/task-spaces"],
+    refetchInterval: 10000, // Poll every 10 seconds for real-time updates
   });
 
   const getChildren = (parentId: string | null) =>

--- a/client/src/components/tasks/TaskActivityTimeline.tsx
+++ b/client/src/components/tasks/TaskActivityTimeline.tsx
@@ -74,6 +74,7 @@ export function TaskActivityTimeline({
       const res = await apiRequest("GET", `/api/tasks/${taskId}/activity?limit=${limit}`);
       return res.json();
     },
+    refetchInterval: 5000, // Poll every 5 seconds for real-time updates
   });
 
   if (isLoading) {

--- a/client/src/pages/tasks.tsx
+++ b/client/src/pages/tasks.tsx
@@ -170,6 +170,7 @@ export default function TasksPage() {
 
   const { data: tasks = [], isLoading, error: tasksError } = useQuery<Task[]>({
     queryKey: ["/api/tasks"],
+    refetchInterval: 3000, // Poll every 3 seconds for real-time updates
   });
 
   const isAdminOrManager = (user as any)?.role === "admin" || (user as any)?.role === "manager";
@@ -217,6 +218,7 @@ export default function TasksPage() {
 
   const { data: spaces = [] } = useQuery<TaskSpace[]>({
     queryKey: ["/api/task-spaces"],
+    refetchInterval: 10000, // Poll every 10 seconds for real-time updates
     retry: false,
     meta: { returnNull: true }, // Don't throw error if forbidden
   });


### PR DESCRIPTION
## Summary
This PR adds automatic polling/refetching intervals to several task-related queries to enable real-time updates of tasks, task spaces, and activity timelines without requiring manual page refreshes.

## Key Changes
- **Tasks Page** (`tasks.tsx`):
  - Added 3-second polling interval to the tasks query for frequent updates
  - Added 10-second polling interval to the task spaces query

- **Task Spaces Sidebar** (`TaskSpacesSidebar.tsx`):
  - Added 10-second polling interval to the task spaces query for consistent updates across components

- **Task Activity Timeline** (`TaskActivityTimeline.tsx`):
  - Added 5-second polling interval to the activity feed query for near real-time activity visibility

## Implementation Details
- Polling intervals are configured via the `refetchInterval` option in React Query's `useQuery` hooks
- Intervals are staggered (3s, 5s, 10s) based on update frequency requirements and performance considerations
- Task spaces use a consistent 10-second interval across both the sidebar and main tasks page for coherent data
- Activity timeline uses a 5-second interval to provide timely visibility of task activity

https://claude.ai/code/session_01Gn9emDnrzMMmRetmx6mr6L