### PR TITLE
Add secure API key authentication and admin key management

### DIFF
--- a/API_KEYS_SETUP.md
+++ b/API_KEYS_SETUP.md
@@ -1,0 +1,45 @@
+# API Keys Setup
+
+MarketingAppOs now supports API keys for programmatic access to protected `/api/*` endpoints that use `isAuthenticated` middleware.
+
+## Security model
+
+- API keys are generated once and shown **only at creation time**.
+- The server stores only a SHA-256 hash of each key (`key_hash`), never plaintext.
+- Keys can be scoped (`scopes` array), expired (`expires_at`), and revoked (`revoked_at`).
+- API key auth maps to a real user, so existing RBAC rules still apply (`requireRole`, `requirePermission`).
+
+## Endpoints (admin only)
+
+All endpoints below require an authenticated admin session:
+
+- `GET /api/api-keys` — list your API keys (metadata only).
+- `POST /api/api-keys` — create a key.
+  - Body:
+    ```json
+    {
+      "name": "Automation Key",
+      "expiresInDays": 30,
+      "scopes": ["api:full"]
+    }
+    ```
+- `DELETE /api/api-keys/:id` — revoke a key.
+
+## Using API keys
+
+Send the key using either header:
+
+- `X-API-Key: mka_<prefix>_<secret>`
+- `Authorization: Bearer mka_<prefix>_<secret>`
+
+Example:
+
+```bash
+curl -H "X-API-Key: mka_xxxxx_xxxxx" https://www.marketingteam.app/api/clients
+```
+
+## Notes
+
+- API keys authenticate as the owner user.
+- If the key owner lacks RBAC permissions for an endpoint, requests are still denied.
+- Existing session-based login continues to work unchanged.

--- a/server/apiKeys.ts
+++ b/server/apiKeys.ts
@@ -1,0 +1,79 @@
+import { randomBytes, createHash, timingSafeEqual } from "crypto";
+import type { Request } from "express";
+import { storage } from "./storage";
+import type { User } from "@shared/schema";
+
+const API_KEY_PREFIX = "mka";
+
+function toSha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function generateApiKey(): {
+  plaintextKey: string;
+  keyPrefix: string;
+  keyHash: string;
+} {
+  const publicPrefix = randomBytes(6).toString("hex");
+  const secret = randomBytes(32).toString("base64url");
+  const plaintextKey = `${API_KEY_PREFIX}_${publicPrefix}_${secret}`;
+
+  return {
+    plaintextKey,
+    keyPrefix: `${API_KEY_PREFIX}_${publicPrefix}`,
+    keyHash: toSha256Hex(plaintextKey),
+  };
+}
+
+function extractApiKeyFromRequest(req: Request): string | null {
+  const headerKey = req.header("x-api-key")?.trim();
+  if (headerKey) return headerKey;
+
+  const authHeader = req.header("authorization")?.trim();
+  if (!authHeader) return null;
+
+  const [scheme, token] = authHeader.split(" ");
+  if (!scheme || !token) return null;
+  if (scheme.toLowerCase() !== "bearer") return null;
+
+  return token.trim();
+}
+
+function safeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export async function authenticateRequestWithApiKey(req: Request): Promise<User | null> {
+  const suppliedApiKey = extractApiKeyFromRequest(req);
+  if (!suppliedApiKey) return null;
+
+  const suppliedHash = toSha256Hex(suppliedApiKey);
+  const apiKeyRecord = await storage.getApiKeyByHash(suppliedHash);
+  if (!apiKeyRecord) return null;
+
+  if (!safeStringEqual(apiKeyRecord.keyHash, suppliedHash)) {
+    return null;
+  }
+
+  if (apiKeyRecord.expiresAt && apiKeyRecord.expiresAt <= new Date()) {
+    return null;
+  }
+
+  const user = await storage.getUser(String(apiKeyRecord.userId));
+  if (!user) {
+    return null;
+  }
+
+  await storage.touchApiKeyLastUsed(apiKeyRecord.id);
+  (req as any).apiKey = {
+    id: apiKeyRecord.id,
+    keyPrefix: apiKeyRecord.keyPrefix,
+    scopes: apiKeyRecord.scopes,
+    userId: apiKeyRecord.userId,
+  };
+
+  return user;
+}


### PR DESCRIPTION
### Motivation
- Provide programmatic access to protected `/api/*` endpoints by introducing scoped, revocable API keys so automation and integrations can authenticate without user sessions.

### Description
- Added a new API keys Drizzle schema `api_keys` and TypeScript types (`apiKeys`, `InsertApiKey`, `ApiKey`) in `shared/schema.ts` and an initial SQL bootstrap in `ensureMinimumSchema()` to create the table and indexes at startup.
- Implemented storage-level operations in `server/storage.ts` to create, lookup (by hash), list, touch (last-used), and revoke API keys and added `getUserByEmail` helper used by auth flows.
- Implemented `server/apiKeys.ts` which generates one-time plaintext keys, computes/stores a SHA-256 `keyHash`, parses `X-API-Key` and `Authorization: Bearer` headers, verifies hashes using timing-safe comparison, enforces expiry/revocation, and attaches API key metadata to `req.apiKey`.
- Extended `isAuthenticated` middleware (`server/auth.ts`) to accept either existing session auth or API key auth (API-key-auth resolves to a real `req.user` so existing RBAC via `requireRole`/`requirePermission` continues to work).
- Added admin-only management endpoints in `server/routes.ts`: `GET /api/api-keys`, `POST /api/api-keys` (returns plaintext key once), and `DELETE /api/api-keys/:id` (revoke), plus a Zod request schema for creation.
- Added operator documentation `API_KEYS_SETUP.md` describing usage, headers, security model, and endpoints.

### Testing
- Module-level sanity imports succeeded: `node --import tsx -e "import('./shared/schema.ts')..."`, `node --import tsx -e "import('./server/apiKeys.ts')..."`, and `node --import tsx -e "import('./server/routes.ts')..."` all returned OK.
- Type-check run `npm run check` was executed but failed due to many pre-existing TypeScript errors unrelated to the API key changes; the API key modules were validated via the targeted import checks above. 
- Manual validation: ensured `ensureMinimumSchema()` contains SQL to create `api_keys` and index creation statements so deployments will create the table during startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69994879efa88325ac48a1c1755bbfb8)