### PR TITLE
Allow internal team roles to access Marketing Center API

### DIFF
--- a/server/routes/marketing-center.ts
+++ b/server/routes/marketing-center.ts
@@ -188,16 +188,29 @@ export async function ensureMarketingCenterSchema() {
   return marketingSchemaEnsured;
 }
 
-// Secure all marketing center routes to Admin Only
-router.use(isAuthenticated, requireRole(UserRole.ADMIN), async (_req, _res, next) => {
-  try {
-    await ensureMarketingCenterSchema();
-    return next();
-  } catch (err) {
-    console.error("Marketing Center schema ensure failed:", err);
-    return next(err);
-  }
-});
+// Secure all marketing center routes to internal team roles.
+// This matches UI visibility for `/marketing-center` (all non-client users).
+router.use(
+  isAuthenticated,
+  requireRole(
+    UserRole.ADMIN,
+    UserRole.MANAGER,
+    UserRole.STAFF,
+    UserRole.SALES_AGENT,
+    UserRole.CREATOR_MANAGER,
+    UserRole.CREATOR,
+    UserRole.STAFF_CONTENT_CREATOR,
+  ),
+  async (_req, _res, next) => {
+    try {
+      await ensureMarketingCenterSchema();
+      return next();
+    } catch (err) {
+      console.error("Marketing Center schema ensure failed:", err);
+      return next(err);
+    }
+  },
+);
 
 
 // Get audience statistics for targeting


### PR DESCRIPTION
### Motivation
- Align API authorization with the UI by allowing all internal (non-client) team roles to access `/api/marketing-center/*` instead of limiting access to admins only.

### Description
- Updated the middleware in `server/routes/marketing-center.ts` to use `requireRole(...)` with `UserRole.ADMIN`, `UserRole.MANAGER`, `UserRole.STAFF`, `UserRole.SALES_AGENT`, `UserRole.CREATOR_MANAGER`, `UserRole.CREATOR`, and `UserRole.STAFF_CONTENT_CREATOR`, while preserving `isAuthenticated` and the `ensureMarketingCenterSchema()` call and adding a clarifying comment.

### Testing
- Ran `npm run check` (TypeScript build) which failed due to pre-existing TypeScript errors unrelated to this authorization change.
- Ran `npm run test -- tests/unit/server/middleware/security.test.ts` which exercised middleware behavior but failed due to unrelated rate-limiter/middleware issues reported by the test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699960d83358832596517641a3cbe14b)