### PR TITLE
Harden API key auth compatibility across protected routes

### DIFF
--- a/server/apiKeys.ts
+++ b/server/apiKeys.ts
@@ -68,6 +68,13 @@ export async function authenticateRequestWithApiKey(req: Request): Promise<User 
   }
 
   await storage.touchApiKeyLastUsed(apiKeyRecord.id);
+
+  // Populate legacy auth shape used by some handlers so API key auth can
+  // access the same endpoints as session auth without special-casing.
+  (user as any).claims = { ...(user as any).claims, sub: String(user.id) };
+  (req as any).userId = Number(user.id);
+  (req as any).userRole = user.role;
+
   (req as any).apiKey = {
     id: apiKeyRecord.id,
     keyPrefix: apiKeyRecord.keyPrefix,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2112,10 +2112,14 @@ Examples:
   app.post("/api/tasks/:taskId/comments", isAuthenticated, async (req: Request, res: Response) => {
     try {
       const user = req.user as any;
+      const userId = user?.id ?? user?.claims?.sub;
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
       const validatedData = insertTaskCommentSchema.parse({
         ...req.body,
         taskId: req.params.taskId,
-        userId: user.claims.sub,
+        userId,
       });
       const comment = await storage.createTaskComment(validatedData);
       res.status(201).json(comment);


### PR DESCRIPTION
### Motivation
- Ensure API-key-authenticated requests can access the same protected endpoints as session-authenticated users so API keys can be used to fully control the application.
- Fix failures where handlers still expected a legacy session-shaped user (`claims.sub`) which prevented API-key users from using certain routes.

### Description
- In `server/apiKeys.ts` populate the legacy auth fields when an API key is used by setting `user.claims.sub`, `req.userId`, and `req.userRole` so downstream handlers that expect those fields continue to work.
- In `server/routes.ts` update the task comment creation route to resolve the acting user id from either `user.id` or `user.claims.sub` and return `401` if neither is present to avoid malformed writes.
- Changes are narrowly scoped to `server/apiKeys.ts` and `server/routes.ts` and are intended to make API-key-authenticated requests compatible with existing handlers without broad refactors.

### Testing
- Ran `npm run check` (TypeScript `tsc`) to validate the repo; the type-check run failed due to numerous pre-existing TypeScript issues across the codebase unrelated to these edits. 
- The changes are small, localized, and do not introduce new runtime logic paths beyond aligning shapes for API key auth; no automated unit tests were added or modified in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699960fb03308325b33cd11c67b9e0ee)