### PR TITLE
docs: clarify API access model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ MarketingOS is a full-stack CRM + operations platform for a marketing agency and
 ## Knowledge base
 
 - Start here: [`docs/knowledge-base/README.md`](./docs/knowledge-base/README.md)
+- API contract: [`docs/api-spec.yaml`](./docs/api-spec.yaml)
+
+## API access model
+
+- API integrations can create, update, and delete records when the calling user or key has the required permissions.
+- Access should be treated as role-based and scoped; use least-privilege credentials for automation and external tools.
 
 ## Local development
 
@@ -33,4 +39,3 @@ MarketingOS is a full-stack CRM + operations platform for a marketing agency and
   - `npm run build`
 - Start:
   - `npm start`
-


### PR DESCRIPTION
### Motivation

- Improve discoverability of the API contract and clarify how API permissions and integration credentials should be treated for the project.

### Description

- Added a direct link to the API contract (`docs/api-spec.yaml`) and a short `API access model` section to `README.md` that explains create/update/delete actions are permission-scoped and recommends least-privilege credentials for integrations.

### Testing

- Ran `npm run check`; this repository has pre-existing TypeScript errors and the typecheck run failed, but the change is documentation-only and does not affect application code or types.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699961e054ec8325ba503ca26ee51a45)