### PR TITLE
Register /clients/:id route to fix client profile 404

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import ClientBilling from "@/pages/client-billing";
 import ClientAnalytics from "@/pages/client-analytics";
 import ClientDailyWorkflow from "@/pages/client-daily-workflow";
 import Clients from "@/pages/clients";
+import ClientDetail from "@/pages/client-detail";
 import Campaigns from "@/pages/campaigns";
 import Tasks from "@/pages/tasks";
 import Leads from "@/pages/leads";
@@ -101,6 +102,7 @@ function Router() {
       {!isClient && <ProtectedRoute path="/creator-dashboard" component={CreatorDashboard} allowedRoles={["creator"]} />}
       {!isClient && <ProtectedRoute path="/sales-dashboard" component={SalesDashboard} allowedRoles={["sales_agent"]} />}
       {!isClient && <ProtectedRoute path="/clients" component={Clients} />}
+      {!isClient && <ProtectedRoute path="/clients/:id" component={ClientDetail} />}
       {!isClient && <ProtectedRoute path="/campaigns" component={Campaigns} />}
       {!isClient && <ProtectedRoute path="/tasks" component={Tasks} />}
       {!isClient && <ProtectedRoute path="/leads" component={Leads} />}


### PR DESCRIPTION
### Motivation
- Client profile pages at URLs like `/clients/<id>` were hitting the 404 page because the `ClientDetail` page was not imported or registered in the main app router.

### Description
- Added `import ClientDetail from "@/pages/client-detail";` and registered a protected route `<ProtectedRoute path="/clients/:id" component={ClientDetail} />` in `client/src/App.tsx` so individual client profiles are reachable for non-client users.

### Testing
- Ran the TypeScript check with `npm run check`; the command executed but the project reports many pre-existing TypeScript errors unrelated to this route change, and no new route-related errors were introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf386fa348325962cd80b74daab31)