### PR TITLE
fix(schema): auto-heal missing task timeline columns on startup

### DIFF
--- a/server/ensureSchema.ts
+++ b/server/ensureSchema.ts
@@ -44,6 +44,16 @@ export async function ensureMinimumSchema() {
     `ALTER TABLE IF EXISTS tasks ADD COLUMN IF NOT EXISTS task_progress INTEGER DEFAULT 0;`
   );
 
+  // Tasks: timeline/dependency columns used by task and dashboard queries
+  await safeQuery(
+    "tasks.start_date column",
+    `ALTER TABLE IF EXISTS tasks ADD COLUMN IF NOT EXISTS start_date TIMESTAMP;`
+  );
+  await safeQuery(
+    "tasks.blocks_completion column",
+    `ALTER TABLE IF EXISTS tasks ADD COLUMN IF NOT EXISTS blocks_completion BOOLEAN DEFAULT FALSE;`
+  );
+
   // Tasks: estimated_hours column
   await safeQuery(
     "tasks.estimated_hours column",
@@ -715,4 +725,3 @@ export async function ensureMinimumSchema() {
     `CREATE INDEX IF NOT EXISTS idx_scheduled_ai_commands_next_run_at ON scheduled_ai_commands(next_run_at);`
   );
 }
-


### PR DESCRIPTION
### Motivation
- Production task and dashboard endpoints were returning 500s due to `column "start_date" does not exist`, so the startup schema check needs to ensure those columns exist on older databases.

### Description
- Added `safeQuery` calls in `ensureMinimumSchema()` to run `ALTER TABLE IF EXISTS tasks ADD COLUMN IF NOT EXISTS start_date TIMESTAMP;` and `ALTER TABLE IF EXISTS tasks ADD COLUMN IF NOT EXISTS blocks_completion BOOLEAN DEFAULT FALSE;` so the app can safely select those fields even when the DB schema is out of date.

### Testing
- Ran `npm run check` (TypeScript typecheck); the command surfaced many pre-existing unrelated TS errors in the repo but did not introduce new errors from this change, and the DB changes are additive and idempotent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bfb8538b08325bf8c8824fda319f4)