### PR TITLE
Enable default task notifications and add SMS deadline alerts (+18089139158)

### DIFF
--- a/client/src/components/tasks/TaskNotificationSettings.tsx
+++ b/client/src/components/tasks/TaskNotificationSettings.tsx
@@ -60,13 +60,13 @@ const defaultPreferences: NotificationPreferences = {
   taskAssigned: { email: true, push: true, inApp: true },
   taskDueSoon: { email: true, push: true, inApp: true },
   taskOverdue: { email: true, push: true, inApp: true },
-  taskCompleted: { email: false, push: false, inApp: true },
+  taskCompleted: { email: true, push: true, inApp: true },
   taskMentioned: { email: true, push: true, inApp: true },
-  taskCommented: { email: false, push: true, inApp: true },
-  fileAttached: { email: false, push: false, inApp: true },
-  dependencyResolved: { email: false, push: true, inApp: true },
+  taskCommented: { email: true, push: true, inApp: true },
+  fileAttached: { email: true, push: true, inApp: true },
+  dependencyResolved: { email: true, push: true, inApp: true },
   milestoneReached: { email: true, push: true, inApp: true },
-  weeklyDigest: { email: true, push: false, inApp: false },
+  weeklyDigest: { email: true, push: true, inApp: true },
 };
 
 const notificationEvents = [
@@ -96,7 +96,7 @@ const notificationEvents = [
     label: "Task Completed",
     description: "When a task you created is completed",
     icon: CheckCircle2,
-    defaultEnabled: false,
+    defaultEnabled: true,
   },
   {
     key: "taskMentioned",
@@ -117,7 +117,7 @@ const notificationEvents = [
     label: "File Attached",
     description: "When a file is attached to your task",
     icon: FileText,
-    defaultEnabled: false,
+    defaultEnabled: true,
   },
   {
     key: "dependencyResolved",

--- a/env.example.txt
+++ b/env.example.txt
@@ -20,6 +20,9 @@ TWILIO_WHATSAPP_NUMBER=+15555555555 # Separate WhatsApp sender if different from
 # Optional: use a Twilio Messaging Service (recommended for higher volume / easier sender management)
 # If set, the server will use messagingServiceSid instead of TWILIO_PHONE_NUMBER.
 TWILIO_MESSAGING_SERVICE_SID=
+
+# SMS recipient for system-wide alert notifications (task deadlines, etc.)
+NOTIFICATION_ALERT_SMS_TO=+18089139158
 #
 # --- Booking SMS confirmations (public /api/bookings) ---
 # Send a transactional SMS to the person who books a strategy session.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -253,6 +253,8 @@ export interface IStorage {
     emailNotifications: boolean;
     taskUpdates: boolean;
     dueDateReminders: boolean;
+    smsNotifications: boolean;
+    soundNotifications: boolean;
   }>;
 
   // Lead operations
@@ -1509,6 +1511,8 @@ export class DatabaseStorage implements IStorage {
     emailNotifications: boolean;
     taskUpdates: boolean;
     dueDateReminders: boolean;
+    smsNotifications: boolean;
+    soundNotifications: boolean;
   }> {
     // For now, return default preferences (all enabled)
     // In the future, this should query a notification_preferences table
@@ -1517,6 +1521,8 @@ export class DatabaseStorage implements IStorage {
       emailNotifications: true,
       taskUpdates: true,
       dueDateReminders: true,
+      smsNotifications: true,
+      soundNotifications: true,
     };
   }
 

--- a/server/taskAutomation.ts
+++ b/server/taskAutomation.ts
@@ -2,7 +2,7 @@ import cron from "node-cron";
 import { storage } from "./storage";
 import { sendPushToUser } from "./push";
 import { emailNotifications } from "./emailService";
-import { checkAndNotifyTaskDeadlines } from "./notificationService";
+import { checkAndNotifyTaskDeadlines, sendTaskDeadlineSmsAlert } from "./notificationService";
 import { log } from "./vite";
 
 export function startTaskAutomation() {
@@ -79,6 +79,12 @@ export function startTaskAutomation() {
             body: `Task "${task.title}" is due tomorrow!`,
             url: `/tasks?taskId=${task.id}`,
           }).catch(err => console.error('Failed to send push notification:', err));
+
+          void sendTaskDeadlineSmsAlert(
+            '📅 Task Due Tomorrow',
+            `Task "${task.title}" is due tomorrow!`,
+            `/tasks?taskId=${task.id}`,
+          );
         }
       }
     } catch (error) {
@@ -88,4 +94,3 @@ export function startTaskAutomation() {
   
   console.log("🚀 Task automation service started");
 }
-


### PR DESCRIPTION
### Motivation
- Increase notification coverage so users receive email/push/in‑app (and sound/SMS where appropriate) for important task events and deadlines.
- Provide a simple, configurable system-wide SMS alert for high-visibility deadline reminders.
- Keep defaults permissive so new users see timely updates until per-user preferences are implemented/stored.

### Description
- Enabled all default channels (email, push, in‑app) for task events in `client/src/components/tasks/TaskNotificationSettings.tsx` so events like task completed, file attached, dependency resolved and weekly digest start enabled by default.  
- Added `sendTaskDeadlineSmsAlert` in `server/notificationService.ts` which calls the existing `sendSms` helper and logs failures, and invoked it for per-user `checkAndNotifyTaskDeadlines` flows.  
- Wired daily “due tomorrow” automation in `server/taskAutomation.ts` to call `sendTaskDeadlineSmsAlert` as well.  
- Added `NOTIFICATION_ALERT_SMS_TO` to `env.example.txt` with default `+18089139158` and introduced a `defaultSmsRecipient` fallback; extended storage typing/defaults in `server/storage.ts` to include `smsNotifications` and `soundNotifications` (both default to `true`).

### Testing
- Ran TypeScript check with `npm run check`; the command completed but the repository has many unrelated TypeScript errors and the typecheck fails (examples: `client/src/components/LeadsKanban.tsx` and `server/stripeService.ts`), so the new changes themselves compile in the runtime context but full repo type errors remain.  
- No additional automated tests were added or run for SMS sending since outbound SMS depends on Twilio env vars (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and sender configuration).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d43dfd2a08325a59930e58a3132f2)